### PR TITLE
change API to demand globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "http://github.com/OwlFonk/OwlCarousel2/issues",
     "email": "owl@owlgraphic.com"
   },
+  "main": "src/js/owl.carousel.js",
   "devDependencies": {
     "assemble": "~0.4.37",
     "grunt": "~0.4.5",
@@ -33,10 +34,6 @@
     "grunt-contrib-qunit": ">=0.2.1",
     "load-grunt-tasks": "^0.4.0",
     "pretty": "^0.1.2"
-   
-  },
-  "engines": {
-    "node": "~0.10.28"
   },
   "keywords": [
     "responsive",

--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -5,7 +5,7 @@
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-;(function($, window, document, undefined) {
+function owlCarouselAutoplay($, window, document, undefined) {
 
 	/**
 	 * Creates the autoplay plugin.
@@ -158,4 +158,7 @@
 
 	$.fn.owlCarousel.Constructor.Plugins.autoplay = Autoplay;
 
-})(window.Zepto || window.jQuery, window, document);
+}
+
+module.exports = owlCarouselAutoplay;
+

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -9,7 +9,7 @@
  * @todo Test Zepto
  * @todo stagePadding calculate wrong active classes
  */
-;(function($, window, document, undefined) {
+function owlCarousel($, window, document, undefined) {
 
 	/**
 	 * Creates a carousel.
@@ -1651,4 +1651,6 @@
 	 */
 	$.fn.owlCarousel.Constructor = Owl;
 
-})(window.Zepto || window.jQuery, window, document);
+}
+
+module.exports = owlCarousel;

--- a/src/js/owl.support.modernizr.js
+++ b/src/js/owl.support.modernizr.js
@@ -6,7 +6,7 @@
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-;(function($, Modernizr, window, document, undefined) {
+function owlCarouselModernizr($, Modernizr, window, document, undefined) {
 
 	var events = {
 		transition: {
@@ -54,4 +54,6 @@
 		$.support.transform = new String(Modernizr.prefixed('transform'));
 		$.support.transform3d = Modernizr.csstransforms3d;
 	}
-})(window.Zepto || window.jQuery, window.Modernizr, window, document);
+}
+
+module.exports = owlCarouselModernizr;


### PR DESCRIPTION
Change modules we use to be commonjs and not depend on globals.

This will eliminate need for custom webpack configuration and non-static dependencies in our code. Will be coupled with an update to consume it correctly in s0.

Also removes node version dependency, which causes this module to fail to build when consumed by npm since it requests a very old version of node.
